### PR TITLE
accomodate array in embedDistanceMatrix

### DIFF
--- a/embedding.py
+++ b/embedding.py
@@ -108,7 +108,12 @@ def embedDistanceMatrix(dmatDf, method='kpca', n_components=2, **kwargs):
         return
 
     assert xy.shape[0] == dmatDf.shape[0]
-    xyDf = pd.DataFrame(xy[:, :n_components], index=dmatDf.index, columns=np.arange(n_components))
+    
+    if isinstance(dmatDF, pd.DataFrame):
+        xyDf = pd.DataFrame(xy[:, :n_components], index=dmatDf.index, columns=np.arange(n_components))
+    else:
+        xyDf = pd.DataFrame(xy[:, :n_components], columns=np.arange(n_components))
+        
     if method == 'kpca':
         """Not sure how negative eigenvalues should be handled here, but they are usually
         small so it shouldn't make a big difference"""


### PR DESCRIPTION
accomodate array as input argument dmatDF in embedDistanceMatrix()
see issue #2 for explanation


https://github.com/agartland/utils/blob/b61935a860838a0e70afde7c9ecf2c68f51a2c4b/embedding.py#L63-L69

Note that the upper portion of the function is meant to accomodate either numpy.array or pd.DataFrame passed to dmatDf, but if numpy array is supplied then L111 will raise an error:

https://github.com/agartland/utils/blob/b61935a860838a0e70afde7c9ecf2c68f51a2c4b/embedding.py#L111


Example
```python
embedDistanceMatrix(dmatDf = pd.DataFrame(tr.pw_beta[0:10,:][:,0:10]), method = "mds")
```
👍 

```python
embedDistanceMatrix(dmatDf = tr.pw_beta[0:10,:][:,0:10], method = "mds")
```
👎 
```
AttributeError: 'numpy.ndarray' object has no attribute 'index'
```